### PR TITLE
fix(ci): skip workflows in template repo

### DIFF
--- a/.github/workflows/gh-pages.yaml
+++ b/.github/workflows/gh-pages.yaml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   deploy:
+    # Skip in template repo - only run in repos created from template
+    if: github.repository != 'aRustyDev/tmpl-mdbook-plugin'
     runs-on: ubuntu-20.04
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -5,6 +5,8 @@ on:
       - main
 jobs:
   run:
+    # Skip in template repo - only run in repos created from template
+    if: github.repository != 'aRustyDev/tmpl-mdbook-plugin'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Added `if: github.repository != 'aRustyDev/tmpl-mdbook-plugin'` condition to both workflows
- Prevents unnecessary workflow runs in the template repo itself
- Workflows automatically enable in repos created from this template

## Files Changed

- `.github/workflows/gh-pages.yaml`
- `.github/workflows/mdbook.yaml`

## Test plan

- [ ] Verify workflows are skipped on this PR (in template repo)
- [ ] Create a test repo from template and verify workflows run

🤖 Generated with [Claude Code](https://claude.com/claude-code)